### PR TITLE
Support multiple prompt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,30 @@ pip install openai
 
 ## Usage
 
-Create a text file containing the natural language description of your app:
+Create one or more text files containing the natural language description of your app. Multiple files are concatenated in the order provided:
 
 ```text
 Create a todo application. It should display a list of items and allow adding
 new ones. Use functional React components.
 ```
 
+You can also define separate pieces of the application in different files. For
+example `examples/Puppy.txt` contains:
+
+```text
+Puppy is an object.
+It has the following properties:
+- an integer to store weight
+- a string to store name
+It has an initialization function called eat which takes two parameters, weight
+and eat.
+```
+
 Run the generator:
 
 ```bash
 export OPENAI_API_KEY=YOUR_KEY
-python -m aclimabot.cli prompt.txt -o my-react-app
+python -m aclimabot.cli prompt.txt examples/Puppy.txt -o my-react-app
 ```
 
 A deterministic answer is requested by setting `temperature=0`. The generated

--- a/aclimabot/cli.py
+++ b/aclimabot/cli.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
 import openai
 
@@ -31,9 +31,10 @@ def call_openai(prompt: str, model: str = "gpt-4o") -> str:
     return response.choices[0].message.content
 
 
-def generate_react_app(prompt_file: Path, output: Optional[Path] = None) -> None:
-    """Generate a React app from a natural language prompt."""
-    prompt = prompt_file.read_text()
+def generate_react_app(prompt_files: Iterable[Path], output: Optional[Path] = None) -> None:
+    """Generate a React app from one or more natural language prompts."""
+    prompt_parts = [p.read_text() for p in prompt_files]
+    prompt = "\n\n".join(prompt_parts)
     generated = call_openai(prompt)
 
     if output is None:
@@ -45,7 +46,12 @@ def generate_react_app(prompt_file: Path, output: Optional[Path] = None) -> None
 
 def main(argv: Optional[list[str]] = None) -> None:
     parser = argparse.ArgumentParser(description="Generate React code from prompts.")
-    parser.add_argument("prompt", type=Path, help="Path to the text prompt file")
+    parser.add_argument(
+        "prompt",
+        type=Path,
+        nargs="+",
+        help="Path(s) to one or more text prompt files",
+    )
     parser.add_argument("-o", "--output", type=Path, help="Output directory")
     parser.add_argument("--model", default="gpt-4o", help="OpenAI model name")
     args = parser.parse_args(argv)

--- a/examples/Puppy.txt
+++ b/examples/Puppy.txt
@@ -1,0 +1,5 @@
+Puppy is an object.
+It has the following properties:
+- an integer to store weight
+- a string to store name
+It has an initialization function called eat which takes two parameters, weight and eat.


### PR DESCRIPTION
## Summary
- allow specifying multiple prompt files and concatenate them
- add an example natural language object description in `examples/Puppy.txt`
- update usage docs to show the new feature

## Testing
- `pytest -q`
- `python -m py_compile aclimabot/cli.py aclimabot/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6841f7899ad08326b266e7143d6df922